### PR TITLE
Add update action

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,11 @@
             <artifactId>batik-transcoder</artifactId>
             <version>1.17</version>
         </dependency>
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/mars/venus/VenusUI.java
+++ b/src/main/java/mars/venus/VenusUI.java
@@ -134,6 +134,7 @@ public class VenusUI extends JFrame {
     private SettingsPreferencesAction settingsPreferencesAction;
 
     private HelpHelpAction helpHelpAction;
+    private HelpUpdateAction helpUpdateAction;
     private HelpAboutAction helpAboutAction;
 
     /**
@@ -322,6 +323,7 @@ public class VenusUI extends JFrame {
         settingsPreferencesAction = new SettingsPreferencesAction(this, "Preferences...", null, "", null, null);
 
         helpHelpAction = new HelpHelpAction(this, "Help...", getSVGActionIcon("help.svg"), "Help", KeyEvent.VK_H, KeyStroke.getKeyStroke(KeyEvent.VK_H, tk.getMenuShortcutKeyMaskEx()));
+        helpUpdateAction = new HelpUpdateAction(this, "Update...", getSVGActionIcon("update.svg"), "Check for updates", null, null);
         helpAboutAction = new HelpAboutAction(this, "About...", getSVGActionIcon("about.svg"), "Information about " + Application.NAME, null, null);
     }
 
@@ -428,6 +430,7 @@ public class VenusUI extends JFrame {
         JMenu helpMenu = new JMenu("Help");
         helpMenu.setMnemonic(KeyEvent.VK_H);
         helpMenu.add(createMenuItem(helpHelpAction));
+        helpMenu.add(createMenuItem(helpUpdateAction));
         helpMenu.add(createMenuItem(helpAboutAction));
         menuBar.add(helpMenu);
 

--- a/src/main/java/mars/venus/actions/help/HelpUpdateAction.java
+++ b/src/main/java/mars/venus/actions/help/HelpUpdateAction.java
@@ -1,0 +1,86 @@
+package mars.venus.actions.help;
+
+import mars.Application;
+import mars.venus.VenusUI;
+import mars.venus.actions.VenusAction;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import javax.swing.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
+import java.io.IOException;
+import java.lang.module.ModuleDescriptor.Version;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Action to check for updates (Help -> Update menu item)
+ *
+ * @author Colin Wong
+ */
+public class HelpUpdateAction extends VenusAction {
+    private static final String UPDATE_URL = "https://api.github.com/repos/xarkenz/mars-red/releases";
+
+    public HelpUpdateAction(VenusUI gui, String name, Icon icon, String description, Integer mnemonic, KeyStroke accel) {
+        super(gui, name, icon, description, mnemonic, accel);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(new URI(UPDATE_URL))
+                    .timeout(Duration.of(5, ChronoUnit.SECONDS))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient().send(request, HttpResponse.BodyHandlers.ofString());
+            JSONArray releaseArray = new JSONArray(response.body());
+
+            // Parse releases into versions and URLs from json response
+            Map<Version, String> versionsToUrls = new HashMap<>();
+            for (int i = 0; i < releaseArray.length(); i++) {
+                JSONObject release = releaseArray.getJSONObject(i);
+                String releaseVersion = release.getString("tag_name");
+                // Remove leading 'v' before tag name
+                if (releaseVersion.startsWith("v"))
+                    releaseVersion = releaseVersion.replaceFirst("v", "");
+                versionsToUrls.put(Version.parse(releaseVersion), release.getString("html_url"));
+            }
+            // Sort version entries in decreasing order
+            List<Map.Entry<Version, String>> sortedVersions = versionsToUrls.entrySet().stream()
+                    .sorted(Map.Entry.comparingByKey(Comparator.reverseOrder()))
+                    .toList();
+
+            // Check if largest fetched version is "greater than" current version
+            Version currentVersion = Version.parse(Application.VERSION);
+            if (!sortedVersions.isEmpty() && sortedVersions.get(0).getKey().compareTo(currentVersion) > 0) {
+                Map.Entry<Version, String> newestVersion = sortedVersions.get(0);
+                if (JOptionPane.showConfirmDialog(this.gui,
+                        "Update found:\n"
+                                + "Current version: " + currentVersion + "\tNew version: " + newestVersion.getKey() + "\n"
+                                + "Go to release page?",
+                        "Update " + Application.NAME,
+                        JOptionPane.YES_NO_OPTION) == 0) {
+                    Desktop.getDesktop().browse(new URI(newestVersion.getValue()));
+                }
+            } else {
+                JOptionPane.showMessageDialog(this.gui, "All up-to-date!", "Update " + Application.NAME, JOptionPane.INFORMATION_MESSAGE);
+            }
+        } catch (IOException var3) {
+            System.out.println("Error 504: could not open update page");
+        } catch (URISyntaxException var4) {
+            System.out.println("Error 503: could not open update page");
+        } catch (InterruptedException ex) {
+            System.out.println("Error: update request timeout exceeded");
+        }
+    }
+}

--- a/src/main/resources/icons/actions/update.svg
+++ b/src/main/resources/icons/actions/update.svg
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25)"
+   sodipodi:docname="update.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#111111"
+     borderopacity="1"
+     inkscape:showpageshadow="0"
+     inkscape:pageopacity="0"
+     inkscape:pagecheckerboard="1"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="px"
+     inkscape:zoom="13.823268"
+     inkscape:cx="13.166206"
+     inkscape:cy="13.600257"
+     inkscape:window-width="1680"
+     inkscape:window-height="935"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     showgrid="true">
+    <inkscape:grid
+       id="grid1"
+       units="px"
+       originx="3.7252903e-07"
+       originy="3.7252903e-07"
+       spacingx="1"
+       spacingy="1"
+       empcolor="#0099e5"
+       empopacity="0.30196078"
+       color="#0099e5"
+       opacity="0.14901961"
+       empspacing="4"
+       dotted="false"
+       gridanglex="30"
+       gridanglez="30"
+       visible="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       style="fill:none;stroke:#bbbbbb;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       id="path1"
+       class="foreground stroke"
+       sodipodi:type="arc"
+       sodipodi:cx="12"
+       sodipodi:cy="12"
+       sodipodi:rx="9"
+       sodipodi:ry="9"
+       sodipodi:start="0.40757096"
+       sodipodi:end="5.4800955"
+       sodipodi:arc-type="arc"
+       d="M 20.262777,15.567424 A 9,9 0 0 1 11.057579,20.950522 9,9 0 0 1 3.1754167,13.768256 9,9 0 0 1 7.6818168,4.1035898 9,9 0 0 1 18.250382,5.5244518"
+       sodipodi:open="true" />
+    <path
+       sodipodi:type="star"
+       style="fill:#bbbbbb;fill-opacity:1"
+       id="path3"
+       class="foreground fill"
+       inkscape:flatsided="true"
+       sodipodi:sides="3"
+       sodipodi:cx="18.548298"
+       sodipodi:cy="6.081409"
+       sodipodi:r1="2.2684603"
+       sodipodi:r2="1.3052303"
+       sodipodi:arg1="2.9902172"
+       sodipodi:arg2="4.0374147"
+       inkscape:rounded="0.12"
+       inkscape:randomized="0"
+       d="m 16.305778,6.4234882 c -0.0711,-0.4660989 2.628327,-2.6266729 3.06753,-2.4551977 0.439204,0.1714752 0.960603,3.589534 0.592499,3.8841577 -0.368104,0.2946237 -3.588929,-0.962861 -3.660029,-1.42896 z"
+       inkscape:transform-center-x="0.22496034"
+       inkscape:transform-center-y="-0.25409871"
+       transform="translate(0.41809685,0.38008805)" />
+    <rect
+       style="fill:#bbbbbb;fill-opacity:1"
+       id="rect4"
+       class="foreground fill"
+       width="2"
+       height="6"
+       x="11"
+       y="7"
+       rx="1"
+       ry="1" />
+    <rect
+       style="fill:#bbbbbb;fill-opacity:1"
+       id="rect4-1"
+       class="foreground fill"
+       width="2"
+       height="6"
+       x="-1.0000004"
+       y="-21.971849"
+       rx="1"
+       ry="1"
+       transform="rotate(135)" />
+  </g>
+</svg>


### PR DESCRIPTION
Inspired by MARS Plus's Update action, this update action checks the GitHub releases for new releases and uses Java's built-in Version class to compare versions to check if there is a newer version available. This also includes a newly created custom SVG for the update icon.
<img width="206" alt="image" src="https://github.com/xarkenz/mars-red/assets/32407067/b7f975af-eb8f-46d7-9c27-40e31ab3856d">
<img width="374" alt="image" src="https://github.com/xarkenz/mars-red/assets/32407067/84eb8123-fad4-46f8-ab1d-37d3bf878dd2">

Changing Application.VERSION to `5.0-beta1`:
<img width="476" alt="image" src="https://github.com/xarkenz/mars-red/assets/32407067/d1591273-8847-4a05-add7-08dcfe11b139">
