### PR TITLE
Add exit code to message console

### DIFF
--- a/src/main/java/mars/ErrorMessage.java
+++ b/src/main/java/mars/ErrorMessage.java
@@ -165,7 +165,7 @@ public class ErrorMessage {
                 this.line = line;
             }
             else {
-                mars.assembler.SourceLine sourceLine = sourceProgram.getSourceLines().get(line - 1);
+                mars.assembler.SourceLine sourceLine = sourceProgram.getSourceLines().get(Math.max(0, line - 1));
                 this.filename = sourceLine.getFilename();
                 this.line = sourceLine.getLineNumber();
             }

--- a/src/main/java/mars/ProcessingException.java
+++ b/src/main/java/mars/ProcessingException.java
@@ -42,6 +42,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 public class ProcessingException extends Exception {
     private final ErrorList errs;
+    private int exitCode = 0;
 
     /**
      * Constructor for ProcessingException.
@@ -107,6 +108,19 @@ public class ProcessingException extends Exception {
     /**
      * Constructor for ProcessingException.
      * <p>
+     * No error list, but allows passing of exit code (i.e., syscall 17
+     * for exiting with exit code).
+     *
+     * @param exitCode exit code
+     */
+    public ProcessingException(int exitCode) {
+        errs = null;
+        this.exitCode = exitCode;
+    }
+
+    /**
+     * Constructor for ProcessingException.
+     * <p>
      * No parameter and thus no error list.  Use this for normal MIPS
      * program termination (e.g. syscall 10 for exit).
      */
@@ -124,4 +138,11 @@ public class ProcessingException extends Exception {
     public ErrorList errors() {
         return errs;
     }
+
+    /**
+     * Produce the error code passed by the program.
+     *
+     * @return Returns the error code.
+     */
+    public int exitCode() { return exitCode; }
 }

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallExit2.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallExit2.java
@@ -48,13 +48,14 @@ public class SyscallExit2 extends AbstractSyscall {
     /**
      * Performs syscall function to exit the MIPS program with return value given in $a0.
      * If running in command mode, MARS will exit with that value.  If running under GUI,
-     * return value is ignored.
+     * return value is displayed in the message console.
      */
     @Override
     public void simulate(ProgramStatement statement) throws ProcessingException {
+        int exitCode = RegisterFile.getValue(4);
         if (Application.getGUI() == null) {
             Application.exitCode = RegisterFile.getValue(4);
         }
-        throw new ProcessingException(); // Empty error list indicates a clean exit
+        throw new ProcessingException(exitCode); // Pass exit code to message console
     }
 }

--- a/src/main/java/mars/simulator/Simulator.java
+++ b/src/main/java/mars/simulator/Simulator.java
@@ -7,8 +7,6 @@ import mars.mips.hardware.Memory;
 import mars.mips.hardware.RegisterFile;
 import mars.mips.instructions.BasicInstruction;
 import mars.util.Binary;
-import mars.venus.*;
-import mars.venus.execute.ExecuteTab;
 import mars.venus.execute.ProgramStatus;
 import mars.venus.execute.RunSpeedPanel;
 
@@ -370,7 +368,7 @@ public class Simulator {
             catch (Exception exception) {
                 // Should only happen if there is a bug somewhere
                 System.err.println("Error: unhandled exception during simulation:");
-                exception.printStackTrace();
+                exception.printStackTrace(System.err);
                 this.simulator.dispatchFinishEvent(this.maxSteps, this.programCounter, SimulatorFinishEvent.Reason.INTERNAL_ERROR, null);
             }
         }
@@ -479,7 +477,7 @@ public class Simulator {
                     }
                     catch (ProcessingException exception) {
                         if (exception.errors() == null) {
-                            this.simulator.dispatchFinishEvent(this.maxSteps, this.programCounter, SimulatorFinishEvent.Reason.EXIT_SYSCALL, null);
+                            this.simulator.dispatchFinishEvent(this.maxSteps, this.programCounter, SimulatorFinishEvent.Reason.EXIT_SYSCALL, exception);
                             return;
                         }
 

--- a/src/main/java/mars/venus/MessagesPane.java
+++ b/src/main/java/mars/venus/MessagesPane.java
@@ -453,8 +453,14 @@ public class MessagesPane extends JTabbedPane implements SimulatorListener {
     public void simulatorFinished(SimulatorFinishEvent event) {
         switch (event.reason()) {
             case EXIT_SYSCALL -> {
-                this.writeToMessages(Simulator.class.getSimpleName() + ": finished simulation successfully.\n");
-                this.writeToConsole("\n--- program finished ---\n\n");
+                int exitCode = event.exception().exitCode();
+                if (exitCode == 0) {
+                    this.writeToMessages(Simulator.class.getSimpleName() + ": finished simulation successfully.\n");
+                }
+                else {
+                    this.writeToMessages(Simulator.class.getSimpleName() + ": finished simulation with exit code " + exitCode + ".\n");
+                }
+                this.writeToConsole("\n--- program finished (code " + exitCode + ") ---\n\n");
                 this.setSelectedComponent(consoleTab);
             }
             case RAN_OFF_BOTTOM -> {

--- a/src/main/resources/help/SyscallHelp.html
+++ b/src/main/resources/help/SyscallHelp.html
@@ -92,7 +92,7 @@
         <tr><td>Write File</td>       <td>15</td>  <td><code>$a0</code> &mdash; file descriptor<br><code>$a1</code> &mdash; address of output buffer<br><code>$a2</code> &mdash; number of characters to write</td>  <td><code>$v0</code> &mdash; number of characters written (negative if an error occurred)</td></tr>
         <tr><td>Close File</td>       <td>16</td>  <td><code>$a0</code> &mdash; file descriptor</td>  <td></td></tr>
         <tr><td>Exit2<br><i>(terminate with exit code)</i></td>  <td>17</td>  <td><code>$a0</code> &mdash; integer exit code</td>  <td><p>
-            Program execution is terminated immediately. If the program is run from within the MARS graphical user interface (GUI), the exit code in <code>$a0</code> is ignored.
+            Program execution is terminated immediately. If the program is run from within the MARS graphical user interface (GUI), the exit code in <code>$a0</code> is displayed in the message console.
         </p></td></tr>
         <tr><td colspan="4"><p>
             <b>Note:</b> Services 1 through 17 above are compatible with the SPIM simulator, though Open File (13) lacks some support. Services 30 and higher are exclusive to MARS.


### PR DESCRIPTION
Adds exit code provided by syscall 17 (Exit2) to the "program finished" message displayed in the console (prints 0 if successful or finished through syscall 10 (Exit)).

Also fixes exception in printing error message when `line` is 0.