### PR TITLE
MARS Tool Syscalls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>mars</groupId>
     <artifactId>mars-red</artifactId>
-    <version>v5.0-beta7</version>
+    <version>v5.0-beta8</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/mars/Application.java
+++ b/src/main/java/mars/Application.java
@@ -58,7 +58,7 @@ public class Application {
     /**
      * The current MARS Red version number.
      */
-    public static final String VERSION = "5.0-beta7";
+    public static final String VERSION = "5.0-beta8";
     /**
      * MARS copyright years.
      */

--- a/src/main/java/mars/mips/instructions/syscalls/AbstractSyscall.java
+++ b/src/main/java/mars/mips/instructions/syscalls/AbstractSyscall.java
@@ -1,5 +1,7 @@
 package mars.mips.instructions.syscalls;
 
+import mars.Application;
+import mars.simulator.ExceptionCause;
 import mars.simulator.SimulatorException;
 import mars.assembler.BasicStatement;
 
@@ -99,4 +101,20 @@ public abstract class AbstractSyscall implements Syscall {
      */
     @Override
     public abstract void simulate(BasicStatement statement) throws SimulatorException, InterruptedException;
+
+    /**
+     * Helper method which throws an exception if running from command-line mode. This should be used for any
+     * syscall involving the GUI.
+     *
+     * @param statement BasicStatement object for this syscall instruction.
+     */
+    protected void requireGUI(BasicStatement statement) throws SimulatorException {
+        if (Application.getGUI() == null) {
+            throw new SimulatorException(
+                statement,
+                "syscall '" + this.getName() + "' (" + this.getNumber() + ") cannot be used in command-line mode",
+                ExceptionCause.SYSCALL
+            );
+        }
+    }
 }

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallConfirmDialog.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallConfirmDialog.java
@@ -53,6 +53,8 @@ public class SyscallConfirmDialog extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments: $a0 = address of null-terminated string that is the message to user
         // Output: $a0 contains value of user-chosen option
         //   0: Yes

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogDouble.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogDouble.java
@@ -52,6 +52,8 @@ public class SyscallInputDialogDouble extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments: $a0 = address of null-terminated string that is the message to user
         // Outputs:
         //    $f0 and $f1 contains value of double read. $f1 contains high order word of the double.

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogFloat.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogFloat.java
@@ -54,6 +54,8 @@ public class SyscallInputDialogFloat extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments: $a0 = address of null-terminated string that is the message to user
         // Outputs:
         //    $f0 contains value of float read

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogInt.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogInt.java
@@ -53,6 +53,8 @@ public class SyscallInputDialogInt extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments: $a0 = address of null-terminated string that is the message to user
         // Outputs:
         //    $a0 contains value of int read

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogString.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallInputDialogString.java
@@ -53,6 +53,8 @@ public class SyscallInputDialogString extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments:
         //    $a0 = address of null-terminated string that is the message to user
         //    $a1 = address of input buffer for the input string

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallLaunchTool.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallLaunchTool.java
@@ -1,0 +1,59 @@
+package mars.mips.instructions.syscalls;
+
+import mars.assembler.BasicStatement;
+import mars.mips.hardware.AddressErrorException;
+import mars.mips.hardware.Memory;
+import mars.mips.hardware.Processor;
+import mars.simulator.ExceptionCause;
+import mars.simulator.SimulatorException;
+import mars.tools.MarsTool;
+import mars.venus.ToolManager;
+
+import javax.swing.*;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Service to open a MARS tool in the GUI as if the menu action was clicked.
+ */
+public class SyscallLaunchTool extends AbstractSyscall {
+    /**
+     * Build an instance of the syscall with its default service number and name.
+     */
+    @SuppressWarnings("unused")
+    public SyscallLaunchTool() {
+        super(62, "LaunchTool");
+    }
+
+    /**
+     * System call to display a message to user.
+     */
+    @Override
+    public void simulate(BasicStatement statement) throws SimulatorException, InterruptedException {
+        this.requireGUI(statement);
+
+        try {
+            // Read a null-terminated string from memory
+            String identifier = Memory.getInstance().fetchNullTerminatedString(Processor.getValue(Processor.ARGUMENT_0));
+            MarsTool tool = ToolManager.getTool(identifier);
+            if (tool == null) {
+                throw new SimulatorException(
+                    statement,
+                    "could not find a tool matching identifier '" + identifier + "'",
+                    ExceptionCause.SYSCALL
+                );
+            }
+
+            SwingUtilities.invokeAndWait(tool::launch);
+        }
+        catch (AddressErrorException exception) {
+            throw new SimulatorException(statement, exception);
+        }
+        catch (InvocationTargetException exception) {
+            throw new SimulatorException(
+                statement,
+                "exception while launching tool: " + exception.getMessage(),
+                ExceptionCause.SYSCALL
+            );
+        }
+    }
+}

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialog.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialog.java
@@ -53,6 +53,8 @@ public class SyscallMessageDialog extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments:
         //   $a0 = address of null-terminated string that is the message to user
         //   $a1 = the type of the message to the user, which is one of:

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogDouble.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogDouble.java
@@ -52,6 +52,8 @@ public class SyscallMessageDialogDouble extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments:
         //   $a0 = address of null-terminated string that is an information-type message to user
         //   $f12 = double value to display in string form after the first message

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogFloat.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogFloat.java
@@ -54,6 +54,8 @@ public class SyscallMessageDialogFloat extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments:
         //   $a0 = address of null-terminated string that is an information-type message to user
         //   $f12 = float value to display in string form after the first message

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogInt.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogInt.java
@@ -53,6 +53,8 @@ public class SyscallMessageDialogInt extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments:
         //   $a0 = address of null-terminated string that is an information-type message to user
         //   $a1 = int value to display in string form after the first message

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogString.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallMessageDialogString.java
@@ -53,6 +53,8 @@ public class SyscallMessageDialogString extends AbstractSyscall {
      */
     @Override
     public void simulate(BasicStatement statement) throws SimulatorException {
+        this.requireGUI(statement);
+
         // Input arguments:
         //   $a0 = address of null-terminated string that is an information-type message to user
         //   $a1 = address of null-terminated string to display after the first message

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallNotifyTool.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallNotifyTool.java
@@ -15,13 +15,13 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * Service to open a MARS tool in the GUI as if the menu action was clicked.
  */
-public class SyscallLaunchTool extends AbstractSyscall {
+public class SyscallNotifyTool extends AbstractSyscall {
     /**
      * Build an instance of the syscall with its default service number and name.
      */
     @SuppressWarnings("unused")
-    public SyscallLaunchTool() {
-        super(62, "LaunchTool");
+    public SyscallNotifyTool() {
+        super(63, "NotifyTool");
     }
 
     /**
@@ -43,7 +43,9 @@ public class SyscallLaunchTool extends AbstractSyscall {
                 );
             }
 
-            SwingUtilities.invokeAndWait(tool::launch);
+            int key = Processor.getValue(Processor.ARGUMENT_1);
+
+            SwingUtilities.invokeAndWait(() -> tool.handleNotify(key));
         }
         catch (AddressErrorException exception) {
             throw new SimulatorException(statement, exception);
@@ -51,7 +53,7 @@ public class SyscallLaunchTool extends AbstractSyscall {
         catch (InvocationTargetException exception) {
             throw new SimulatorException(
                 statement,
-                "exception while launching tool: " + exception.getCause().getMessage(),
+                "exception while notifying tool: " + exception.getCause().getMessage(),
                 ExceptionCause.SYSCALL
             );
         }

--- a/src/main/java/mars/mips/instructions/syscalls/SyscallQueryTool.java
+++ b/src/main/java/mars/mips/instructions/syscalls/SyscallQueryTool.java
@@ -15,13 +15,13 @@ import java.lang.reflect.InvocationTargetException;
 /**
  * Service to open a MARS tool in the GUI as if the menu action was clicked.
  */
-public class SyscallLaunchTool extends AbstractSyscall {
+public class SyscallQueryTool extends AbstractSyscall {
     /**
      * Build an instance of the syscall with its default service number and name.
      */
     @SuppressWarnings("unused")
-    public SyscallLaunchTool() {
-        super(62, "LaunchTool");
+    public SyscallQueryTool() {
+        super(64, "QueryTool");
     }
 
     /**
@@ -43,7 +43,9 @@ public class SyscallLaunchTool extends AbstractSyscall {
                 );
             }
 
-            SwingUtilities.invokeAndWait(tool::launch);
+            int key = Processor.getValue(Processor.ARGUMENT_1);
+
+            SwingUtilities.invokeAndWait(() -> tool.handleQuery(key));
         }
         catch (AddressErrorException exception) {
             throw new SimulatorException(statement, exception);
@@ -51,7 +53,7 @@ public class SyscallLaunchTool extends AbstractSyscall {
         catch (InvocationTargetException exception) {
             throw new SimulatorException(
                 statement,
-                "exception while launching tool: " + exception.getCause().getMessage(),
+                "exception while querying tool: " + exception.getCause().getMessage(),
                 ExceptionCause.SYSCALL
             );
         }

--- a/src/main/java/mars/tools/AbstractMarsTool.java
+++ b/src/main/java/mars/tools/AbstractMarsTool.java
@@ -51,37 +51,18 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  * @author Pete Sanderson, 14 November 2006
  */
-public abstract class AbstractMarsTool extends JFrame implements MarsTool, Memory.Listener {
+public abstract class AbstractMarsTool implements MarsTool, Memory.Listener {
     protected JDialog dialog;
 
-    /**
-     * Descriptive title for title bar provided to constructor.
-     */
-    private final String title;
-
-    /**
-     * Simple constructor
-     *
-     * @param title String containing title bar text
-     */
-    protected AbstractMarsTool(String title) {
-        this.title = title;
+    public String getTitle() {
+        StringBuilder title = new StringBuilder();
+        title.append('[').append(this.getIdentifier()).append("] ").append(this.getDisplayName());
+        String version = this.getVersion();
+        if (version != null && !version.isBlank()) {
+            title.append(' ').append(version);
+        }
+        return title.toString();
     }
-
-    /**
-     * Required MarsTool method to return Tool name.  Must be defined by subclass.
-     *
-     * @return Tool name.  MARS will display this in menu item.
-     */
-    @Override
-    public abstract String getName();
-
-    /**
-     * Abstract method that must be instantiated by subclass to build the main display area
-     * of the GUI.  It will be placed in the CENTER area of a BorderLayout.  The title
-     * is in the NORTH area, and the controls are in the SOUTH area.
-     */
-    protected abstract JComponent buildMainDisplayArea();
 
     /**
      * This is invoked when the user selects this tool from the Tools menu.
@@ -96,8 +77,8 @@ public abstract class AbstractMarsTool extends JFrame implements MarsTool, Memor
      * and {@link #buildMainDisplayArea()} to contain application-specific displays of parameters and results.
      */
     @Override
-    public void action() {
-        this.dialog = new JDialog(Application.getGUI(), this.title);
+    public void launch() {
+        this.dialog = new JDialog(Application.getGUI(), this.getTitle());
         // Ensure the dialog goes away if the user clicks the X
         this.dialog.addWindowListener(new WindowAdapter() {
             @Override
@@ -105,14 +86,24 @@ public abstract class AbstractMarsTool extends JFrame implements MarsTool, Memor
                 AbstractMarsTool.this.closeTool();
             }
         });
+
         this.initializePreGUI();
+
         this.dialog.setContentPane(this.buildContentPane(this.buildMainDisplayArea(), this.buildButtonArea()));
         this.dialog.pack();
         this.dialog.setLocationRelativeTo(Application.getGUI());
         this.dialog.setVisible(true);
+
         this.initializePostGUI();
         this.startObserving();
     }
+
+    /**
+     * Abstract method that must be instantiated by subclass to build the main display area
+     * of the GUI.  It will be placed in the CENTER area of a BorderLayout.  The title
+     * is in the NORTH area, and the controls are in the SOUTH area.
+     */
+    protected abstract JComponent buildMainDisplayArea();
 
     /**
      * Method that will be called once just before the GUI is constructed in the go() and action()

--- a/src/main/java/mars/tools/BHTSimulator.java
+++ b/src/main/java/mars/tools/BHTSimulator.java
@@ -64,14 +64,6 @@ public class BHTSimulator extends AbstractMarsTool {
      * Constant for the default inital value.
      */
     public static final boolean DEFAULT_INITIAL_VALUE = false;
-    /**
-     * The name of the tool.
-     */
-    public static final String NAME = "Branch History Table Simulator";
-    /**
-     * The version of the tool.
-     */
-    public static final String VERSION = "Version 1.0 (Ingo Kofler)";
 
     /**
      * The GUI of the BHT simulator.
@@ -90,12 +82,24 @@ public class BHTSimulator extends AbstractMarsTool {
      */
     private boolean lastBranchTaken;
 
+    @Override
+    public String getIdentifier() {
+        return "bhtsim";
+    }
+
     /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
+     * Returns the name of the tool.
+     *
+     * @return The tool's name as a string.
      */
-    @SuppressWarnings("unused")
-    public BHTSimulator() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getDisplayName() {
+        return "Branch History Table Simulator";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.1";
     }
 
     /**
@@ -140,16 +144,6 @@ public class BHTSimulator extends AbstractMarsTool {
     }
 
     /**
-     * Returns the name of the tool.
-     *
-     * @return The tool's name as a string.
-     */
-    @Override
-    public String getName() {
-        return NAME;
-    }
-
-    /**
      * Perform a reset of the simulator.
      * This causes the BHT to be reseted and the log messages to be cleared.
      */
@@ -191,7 +185,7 @@ public class BHTSimulator extends AbstractMarsTool {
         this.gui.getTable().addRowSelectionInterval(index, index);
 
         // Add output to log
-        this.gui.getLogTextField().append("instruction " + statement.toString() + " at address " + addressString + ", maps to index " + index + "\n");
+        this.gui.getLogTextField().append("instruction " + statement + " at address " + addressString + ", maps to index " + index + "\n");
         this.gui.getLogTextField().append("branches to address " + Binary.intToHexString(BHTSimulator.extractBranchAddress(address, statement)) + "\n");
         this.gui.getLogTextField().append("prediction is: " + (this.tableModel.getPrediction(index) ? "take" : "do not take") + "...\n");
         this.gui.getLogTextField().setCaretPosition(this.gui.getLogTextField().getDocument().getLength());

--- a/src/main/java/mars/tools/BitmapDisplay.java
+++ b/src/main/java/mars/tools/BitmapDisplay.java
@@ -45,8 +45,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * @version 1.1
  */
 public class BitmapDisplay extends AbstractMarsTool {
-    private static final String NAME = "Bitmap Display";
-    private static final String VERSION = "1.1";
 
     // Values for Combo Boxes
     private static final Integer[] UNIT_SIZE_CHOICES = { 1, 2, 4, 8, 16, 32 };
@@ -70,12 +68,9 @@ public class BitmapDisplay extends AbstractMarsTool {
     private JComboBox<String> baseAddressSelector;
     private BitmapCanvas canvas;
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public BitmapDisplay() {
-        super(NAME + ", Version " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "bitmap";
     }
 
     /**
@@ -84,8 +79,13 @@ public class BitmapDisplay extends AbstractMarsTool {
      * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Bitmap Display";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.1";
     }
 
     @Override

--- a/src/main/java/mars/tools/CacheSimulator.java
+++ b/src/main/java/mars/tools/CacheSimulator.java
@@ -59,9 +59,6 @@ public class CacheSimulator extends AbstractMarsTool {
      */
     public boolean debug = false;
 
-    public static final String NAME = "Data Cache Simulator";
-    public static final String VERSION = "Version 1.2";
-
     // Major GUI components
     private JComboBox<Integer> cacheBlockSizeSelector;
     private JComboBox<Integer> cacheBlockCountSelector;
@@ -136,12 +133,9 @@ public class CacheSimulator extends AbstractMarsTool {
     // RNG used for random replacement policy.  For testing, set seed for reproducible stream
     private final Random random = new Random(0);
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public CacheSimulator() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "cachesim";
     }
 
     /**
@@ -150,8 +144,13 @@ public class CacheSimulator extends AbstractMarsTool {
      * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Data Cache Simulator";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.3";
     }
 
     /**

--- a/src/main/java/mars/tools/DigitalLabSimulator.java
+++ b/src/main/java/mars/tools/DigitalLabSimulator.java
@@ -17,8 +17,6 @@ import java.awt.event.MouseEvent;
  * didier.teifreto@univ-fcomte.fr
  */
 public class DigitalLabSimulator extends AbstractMarsTool {
-    private static final String NAME = "Digital Lab Simulator";
-    private static final String VERSION = "Version 1.0 (Didier Teifreto)";
     private static final int IN_OFFSET_DISPLAY_1 = 0x10;
     private static final int IN_OFFSET_DISPLAY_2 = 0x11;
     private static final int IN_OFFSET_HEXADECIMAL_KEYBOARD = 0x12;
@@ -40,17 +38,24 @@ public class DigitalLabSimulator extends AbstractMarsTool {
     private static boolean counterInterruptOnOff = false;
     private static OneSecondCounter secondCounter;
 
+    @Override
+    public String getIdentifier() {
+        return "digitallab";
+    }
+
     /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
+     * Required MarsTool method to return Tool name.
+     *
+     * @return Tool name.  MARS will display this in menu item.
      */
-    @SuppressWarnings("unused")
-    public DigitalLabSimulator() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getDisplayName() {
+        return "Digital Lab Simulator";
     }
 
     @Override
-    public String getName() {
-        return NAME;
+    public String getVersion() {
+        return "1.1";
     }
 
     @Override
@@ -143,6 +148,7 @@ public class DigitalLabSimulator extends AbstractMarsTool {
              If counter interruption is enable, every 30 instructions, an exception is started with cause register bit number 10.
              (contributed by Didier Teifreto, dteifreto@lifc.univ-fcomte.fr)""";
         JButton help = new JButton("Help");
+        help.putClientProperty("JButton.buttonType", "help");
         help.addActionListener(e -> {
             JTextArea ja = new JTextArea(helpContent);
             ja.setRows(20);

--- a/src/main/java/mars/tools/FloatRepresentation.java
+++ b/src/main/java/mars/tools/FloatRepresentation.java
@@ -1,6 +1,5 @@
 package mars.tools;
 
-import mars.Application;
 import mars.mips.hardware.Coprocessor1;
 import mars.mips.hardware.Register;
 import mars.simulator.Simulator;
@@ -47,9 +46,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * As written, it can <i>almost</i> be adapted to 64-bit by changing a few constants.
  */
 public class FloatRepresentation extends AbstractMarsTool implements Register.Listener {
-    private static final String NAME = "Floating-Point Representation";
-    private static final String VERSION = "Version 1.1";
-
     private static final String defaultHex = "00000000";
     private static final String defaultDecimal = "0.0";
     private static final String defaultBinarySign = "0";
@@ -88,22 +84,24 @@ public class FloatRepresentation extends AbstractMarsTool implements Register.Li
     private InstructionsPane instructions;
     private final String defaultInstructions = "Modify any value then press the Enter key to update all values.";
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public FloatRepresentation() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "floatrepr";
     }
 
     /**
-     * Fetch tool name (for display in MARS Tools menu)
+     * Required MarsTool method to return Tool name.
      *
-     * @return String containing tool name
+     * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Floating-Point Representation";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.2";
     }
 
     /**

--- a/src/main/java/mars/tools/InstructionCounter.java
+++ b/src/main/java/mars/tools/InstructionCounter.java
@@ -46,9 +46,6 @@ import java.awt.*;
  * @author Felipe Lessa (felipe.lessa@gmail.com)
  */
 public class InstructionCounter extends AbstractMarsTool {
-    private static final String NAME = "Instruction Counter";
-    private static final String VERSION = "Version 1.0 (Felipe Lessa)";
-
     /**
      * Number of instructions executed until now.
      */
@@ -80,17 +77,24 @@ public class InstructionCounter extends AbstractMarsTool {
      */
     protected int lastAddress = -1;
 
+    @Override
+    public String getIdentifier() {
+        return "instrcount";
+    }
+
     /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
+     * Required MarsTool method to return Tool name.
+     *
+     * @return Tool name.  MARS will display this in menu item.
      */
-    @SuppressWarnings("unused")
-    public InstructionCounter() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getDisplayName() {
+        return "Instruction Counter";
     }
 
     @Override
-    public String getName() {
-        return NAME;
+    public String getVersion() {
+        return "1.1";
     }
 
     @Override

--- a/src/main/java/mars/tools/InstructionStatistics.java
+++ b/src/main/java/mars/tools/InstructionStatistics.java
@@ -46,15 +46,6 @@ import java.util.Arrays;
  */
 public class InstructionStatistics extends AbstractMarsTool {
     /**
-     * name of the tool
-     */
-    private static final String NAME = "Instruction Statistics";
-    /**
-     * version and author information of the tool
-     */
-    private static final String VERSION = "Version 1.0 (Ingo Kofler)";
-
-    /**
      * number of instruction categories used by this tool
      */
     private static final int MAX_CATEGORY = 5;
@@ -118,22 +109,24 @@ public class InstructionStatistics extends AbstractMarsTool {
      */
     protected int lastAddress = -1;
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public InstructionStatistics() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "instrstats";
     }
 
     /**
-     * returns the name of the tool
+     * Required MarsTool method to return Tool name.
      *
-     * @return the tools's name
+     * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Instruction Statistics";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.1";
     }
 
     /**
@@ -143,7 +136,6 @@ public class InstructionStatistics extends AbstractMarsTool {
      */
     @Override
     protected JComponent buildMainDisplayArea() {
-
         // Create GUI elements for the tool
         JPanel panel = new JPanel(new GridBagLayout());
 

--- a/src/main/java/mars/tools/IntroToTools.java
+++ b/src/main/java/mars/tools/IntroToTools.java
@@ -35,25 +35,24 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * The "hello world" of MarsTools!
  */
 public class IntroToTools extends AbstractMarsTool {
-    private static final String NAME = "Introduction to MARS Tools";
-    private static final String VERSION = "Version 1.0";
-
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public IntroToTools() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "helloworld";
     }
 
     /**
-     * Required method to return Tool name.
+     * Required MarsTool method to return Tool name.
      *
      * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Introduction To MARS Tools";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.1";
     }
 
     /**

--- a/src/main/java/mars/tools/KeyboardAndDisplaySimulator.java
+++ b/src/main/java/mars/tools/KeyboardAndDisplaySimulator.java
@@ -72,9 +72,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * @author Pete Sanderson
  */
 public class KeyboardAndDisplaySimulator extends AbstractMarsTool {
-    private static final String NAME = "Keyboard and Display Simulator";
-    private static final String VERSION = "Version 1.4";
-
     private static String displayPanelTitle;
     private static String keyboardPanelTitle;
 
@@ -123,12 +120,9 @@ public class KeyboardAndDisplaySimulator extends AbstractMarsTool {
     private JCheckBox displayAfterDelayCheckBox;
     private JTextArea keyEventAccepter;
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public KeyboardAndDisplaySimulator() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "keydispsim";
     }
 
     /**
@@ -137,8 +131,13 @@ public class KeyboardAndDisplaySimulator extends AbstractMarsTool {
      * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Keyboard and Display Simulator";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.5";
     }
 
     /**
@@ -438,7 +437,7 @@ public class KeyboardAndDisplaySimulator extends AbstractMarsTool {
         Dimension areaSize = display.getSize();
         int widthInPixels = (int) areaSize.getWidth();
         int heightInPixels = (int) areaSize.getHeight();
-        FontMetrics metrics = getFontMetrics(display.getFont());
+        FontMetrics metrics = dialog.getFontMetrics(display.getFont());
         int rowHeight = metrics.getHeight();
         int charWidth = metrics.getMaxAdvance();
         // Estimate number of columns/rows of text that will fit in current window with current font.
@@ -529,6 +528,7 @@ public class KeyboardAndDisplaySimulator extends AbstractMarsTool {
             + "for programming MMIO text-based games.\n\n"
             + "Contact Pete Sanderson at psanderson@otterbein.edu with questions or comments.\n";
         JButton helpButton = new JButton("Help");
+        helpButton.putClientProperty("JButton.buttonType", "help");
         helpButton.addActionListener(event -> {
             JTextArea textArea = new JTextArea(helpContent);
             textArea.setRows(30);

--- a/src/main/java/mars/tools/MarsTool.java
+++ b/src/main/java/mars/tools/MarsTool.java
@@ -37,7 +37,7 @@ import javax.swing.*;
  * and its .class file must be in the same Tools folder as MarsTool.class.
  * Mars will detect a qualifying tool upon startup, create an instance
  * using its no-argument constructor and add it to its Tools menu.
- * When its menu item is selected, the {@link #action()} method will be invoked.
+ * When its menu item is selected, the {@link #launch()} method will be invoked.
  * <p>
  * A tool may receive communication from MIPS system resources
  * (registers or memory) by registering as an observer with
@@ -47,12 +47,20 @@ import javax.swing.*;
  * provided any such communication is done using {@link mars.simulator.Simulator#changeState(Runnable)}.
  */
 public interface MarsTool {
+    default String getIdentifier() {
+        return this.getClass().getSimpleName();
+    }
+
     /**
      * Return the name you have chosen for this tool, which will be used for the
      * menu item.  If not implemented, uses the class name.
      */
-    default String getName() {
-        return this.getClass().getSimpleName();
+    default String getDisplayName() {
+        return this.getIdentifier();
+    }
+
+    default String getVersion() {
+        return null;
     }
 
     /**
@@ -77,5 +85,5 @@ public interface MarsTool {
      * Performs tool functions.  It will be invoked when the tool is selected
      * from the Tools menu.
      */
-    void action();
+    void launch();
 }

--- a/src/main/java/mars/tools/MarsTool.java
+++ b/src/main/java/mars/tools/MarsTool.java
@@ -86,4 +86,8 @@ public interface MarsTool {
      * from the Tools menu.
      */
     void launch();
+
+    void handleNotify(int key);
+
+    void handleQuery(int key);
 }

--- a/src/main/java/mars/tools/MemoryReferenceVisualization.java
+++ b/src/main/java/mars/tools/MemoryReferenceVisualization.java
@@ -44,9 +44,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * Pete Sanderson, verison 1.0, 14 November 2006.
  */
 public class MemoryReferenceVisualization extends AbstractMarsTool {
-    private static final String NAME = "Memory Reference Visualization";
-    private static final String VERSION = "Version 1.0";
-
     // Major GUI components
     private JComboBox<String> wordsPerUnitSelector;
     private JComboBox<String> visualizationUnitPixelWidthSelector;
@@ -108,12 +105,9 @@ public class MemoryReferenceVisualization extends AbstractMarsTool {
     private Grid grid;
     private CounterColorScale counterColorScale;
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public MemoryReferenceVisualization() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "memrefvis";
     }
 
     /**
@@ -122,8 +116,13 @@ public class MemoryReferenceVisualization extends AbstractMarsTool {
      * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "Memory Reference Visualization";
+    }
+
+    @Override
+    public String getVersion() {
+        return "1.1";
     }
 
     /**
@@ -246,6 +245,7 @@ public class MemoryReferenceVisualization extends AbstractMarsTool {
             questions or comments.
             """;
         JButton help = new JButton("Help");
+        help.putClientProperty("JButton.buttonType", "help");
         help.addActionListener(event -> JOptionPane.showMessageDialog(dialog, helpContent));
         return help;
     }

--- a/src/main/java/mars/tools/MipsXray.java
+++ b/src/main/java/mars/tools/MipsXray.java
@@ -32,9 +32,6 @@ import java.util.*;
 import java.util.function.BiConsumer;
 
 public class MipsXray extends AbstractMarsTool {
-    private static final String NAME = "MIPS Datapath X-Ray";
-    private static final String VERSION = "Version 2.0";
-
     protected Graphics graphics;
     // Address of instruction in memory
     protected int lastAddress = -1;
@@ -46,23 +43,26 @@ public class MipsXray extends AbstractMarsTool {
 
     private VenusUI gui;
     private JToolBar toolBar;
+    private JPanel panel;
 
-    /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
-     */
-    @SuppressWarnings("unused")
-    public MipsXray() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getIdentifier() {
+        return "mipsxray";
     }
 
     /**
-     * Required method to return Tool name.
+     * Required MarsTool method to return Tool name.
      *
      * @return Tool name.  MARS will display this in menu item.
      */
     @Override
-    public String getName() {
-        return NAME;
+    public String getDisplayName() {
+        return "MIPS Datapath X-Ray";
+    }
+
+    @Override
+    public String getVersion() {
+        return "2.1";
     }
 
     /**
@@ -71,7 +71,7 @@ public class MipsXray extends AbstractMarsTool {
     @Override
     protected JComponent getHelpComponent() {
         final String helpContent = """
-            This plugin is used to visualize the behavior of mips processor using the default datapath.
+            This plugin is used to visualize the behavior of MIPS processor using the default datapath.
             It reads the source code instruction and generates an animation representing the inputs and
             outputs of functional blocks and the interconnection between them.  The basic signals
             represented are control signals, opcode bits and data of functional blocks.
@@ -83,11 +83,11 @@ public class MipsXray extends AbstractMarsTool {
 
             To see the datapath of register bank and control units, click inside the functional unit.
 
-            Version 2.0
             Developed by Márcio Roberto, Guilherme Sales, Fabrício Vivas, Flávio Cardeal and Fábio Lúcio
             Contact Márcio Roberto at marcio.rdaraujo@gmail.com with questions or comments.
             """;
         JButton help = new JButton("Help");
+        help.putClientProperty("JButton.buttonType", "help");
         help.addActionListener(event -> JOptionPane.showMessageDialog(dialog, helpContent));
         return help;
     }
@@ -101,9 +101,9 @@ public class MipsXray extends AbstractMarsTool {
     }
 
     protected JComponent buildMainDisplayArea(String figure) {
-        gui = Application.getGUI();
+        this.gui = Application.getGUI();
         this.createActionObjects();
-        toolBar = this.setUpToolBar();
+        this.toolBar = this.setUpToolBar();
 
         GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
         GraphicsConfiguration gc = ge.getDefaultScreenDevice().getDefaultConfiguration();
@@ -127,11 +127,12 @@ public class MipsXray extends AbstractMarsTool {
         icon = new ImageIcon(im);
 
         JLabel label = new JLabel(icon);
-        this.getContentPane().add(label, BorderLayout.WEST);
-        this.getContentPane().add(toolBar, BorderLayout.NORTH);
-        this.setResizable(false);
+        this.panel = new JPanel();
+        this.panel.add(label, BorderLayout.WEST);
+        this.panel.add(toolBar, BorderLayout.NORTH);
+        this.dialog.setResizable(false);
 
-        return (JComponent) this.getContentPane();
+        return this.panel;
     }
 
     @Override
@@ -166,13 +167,13 @@ public class MipsXray extends AbstractMarsTool {
         BasicStatement statement = Application.instructionSet.getDecoder().decodeStatement(wordValue);
         instructionBinary = statement.getInstruction().getEncodingDescriptor();
 
-        this.getContentPane().removeAll();
+        this.panel.removeAll();
         // Class panel that runs datapath animation
         DatapathAnimation datapathAnimation = new DatapathAnimation(instructionBinary);
         this.createActionObjects();
         toolBar = this.setUpToolBar();
-        this.getContentPane().add(toolBar, BorderLayout.NORTH);
-        this.getContentPane().add(datapathAnimation, BorderLayout.WEST);
+        this.panel.add(toolBar, BorderLayout.NORTH);
+        this.panel.add(datapathAnimation, BorderLayout.WEST);
         datapathAnimation.startAnimation(instructionBinary);
     }
 

--- a/src/main/java/mars/tools/VisualStack.java
+++ b/src/main/java/mars/tools/VisualStack.java
@@ -10,8 +10,6 @@ import java.awt.*;
 import java.awt.image.BufferedImage;
 
 public class VisualStack extends AbstractMarsTool implements Register.Listener {
-    private static final String NAME = "Visual Stack";
-    private static final String VERSION = "Version 1.0";
     private static final int STACK_VIEWER_WIDTH = 400;
     private static final int STACK_VIEWER_HEIGHT = 400;
 
@@ -20,17 +18,24 @@ public class VisualStack extends AbstractMarsTool implements Register.Listener {
     private int oldStackPtrValue;
     private boolean stackOK = true;
 
+    @Override
+    public String getIdentifier() {
+        return "visualstack";
+    }
+
     /**
-     * Construct an instance of this tool. This will be used by the {@link mars.venus.ToolManager}.
+     * Required MarsTool method to return Tool name.
+     *
+     * @return Tool name.  MARS will display this in menu item.
      */
-    @SuppressWarnings("unused")
-    public VisualStack() {
-        super(NAME + ", " + VERSION);
+    @Override
+    public String getDisplayName() {
+        return "Visual Stack";
     }
 
     @Override
-    public String getName() {
-        return NAME;
+    public String getVersion() {
+        return "1.1";
     }
 
     @Override
@@ -58,8 +63,7 @@ public class VisualStack extends AbstractMarsTool implements Register.Listener {
 
     @Override
     protected JComponent getHelpComponent() {
-        final String helpContent = NAME + ", " + VERSION + """
-
+        final String helpContent = """
             This tool provides a graphical visualization of the MIPS stack. \
             When data is pushed to the stack, a colored rectangle representing the data appears in the appropriate position, along with information about which register the data came from. \
             Visual Stack was written to aid developers of recursive functions in debugging and to help them avoid common stack pitfalls; as such, it distinguishes between return addresses and other types of data. \
@@ -72,6 +76,7 @@ public class VisualStack extends AbstractMarsTool implements Register.Listener {
             This tool was written by James Hester, a student at the University of Texas at Dallas, in November 2014.""";
 
         JButton help = new JButton("Help");
+        help.putClientProperty("JButton.buttonType", "help");
         help.addActionListener(event -> {
             JTextArea textArea = new JTextArea(helpContent);
             textArea.setRows(15);
@@ -139,7 +144,7 @@ public class VisualStack extends AbstractMarsTool implements Register.Listener {
         this.stackViewer.errorOverlay();
         Toolkit.getDefaultToolkit().beep();
         this.stackOK = false;
-        this.repaint();
+        this.dialog.repaint();
     }
 
     @Override
@@ -179,7 +184,7 @@ public class VisualStack extends AbstractMarsTool implements Register.Listener {
         this.stackViewer.advanceStackPointer(0);
         this.oldStackPtrValue = Memory.getInstance().getAddress(MemoryConfigurations.STACK_POINTER);
         this.stackOK = true;
-        this.repaint();
+        this.dialog.repaint();
     }
 
     private static class StackViewer extends JComponent {

--- a/src/main/java/mars/venus/ToolManager.java
+++ b/src/main/java/mars/venus/ToolManager.java
@@ -53,6 +53,7 @@ public class ToolManager {
     private static final String CLASS_EXTENSION = "class";
 
     private static List<ToolAction> toolActions = null;
+    private static Map<String, MarsTool> toolsByIdentifier = null;
 
     // Prevent instances
     private ToolManager() {}
@@ -85,6 +86,7 @@ public class ToolManager {
         // The list will be populated only the first time this is called
         if (toolActions == null) {
             List<MarsTool> marsTools = new ArrayList<>();
+            toolsByIdentifier = new HashMap<>();
 
             // Add any tools stored externally, as listed in values.properties file.
             // This needs some work, because mars.Globals.getExternalTools() returns
@@ -111,7 +113,10 @@ public class ToolManager {
                         continue;
                     }
                     // Obtain an instance of the class
-                    marsTools.add((MarsTool) loadedClass.getDeclaredConstructor().newInstance());
+                    MarsTool tool = (MarsTool) loadedClass.getDeclaredConstructor().newInstance();
+
+                    marsTools.add(tool);
+                    toolsByIdentifier.put(tool.getIdentifier().toLowerCase(), tool);
                 }
                 catch (Exception exception) {
                     System.err.println(ToolManager.class.getSimpleName() + ": " + exception);
@@ -121,11 +126,16 @@ public class ToolManager {
             toolActions = marsTools.stream()
                     .sorted(Comparator
                             .comparing(MarsTool::getToolMenuOrder)
-                            .thenComparing(MarsTool::getName))
+                            .thenComparing(MarsTool::getDisplayName))
                     .map(ToolAction::new)
                     .toList();
         }
 
         return toolActions;
+    }
+
+    public static MarsTool getTool(String identifier) {
+        getToolActions();
+        return toolsByIdentifier.get(identifier.toLowerCase());
     }
 }

--- a/src/main/java/mars/venus/actions/ToolAction.java
+++ b/src/main/java/mars/venus/actions/ToolAction.java
@@ -50,7 +50,7 @@ public class ToolAction extends AbstractAction {
      * @param tool The tool this action will open when performed.
      */
     public ToolAction(MarsTool tool) {
-        super(tool.getName(), tool.getIcon());
+        super(tool.getDisplayName(), tool.getIcon());
         this.tool = tool;
     }
 
@@ -64,14 +64,14 @@ public class ToolAction extends AbstractAction {
     }
 
     /**
-     * Opens this action's corresponding tool by invoking its {@link MarsTool#action()} method.
+     * Opens this action's corresponding tool by invoking its {@link MarsTool#launch()} method.
      *
      * @param event The event that triggered this call.
      */
     @Override
     public void actionPerformed(ActionEvent event) {
         try {
-            this.tool.action();
+            this.tool.launch();
         }
         catch (Exception exception) {
             exception.printStackTrace();


### PR DESCRIPTION
Added three new syscalls: `LaunchTool` (62), which launches a given tool in the GUI if it is not already open; `NotifyTool` (63), which effectively sends a signal to a given tool which is handled in a manner defined by the tool; and `QueryTool` (64), which is very similar to `NotifyTool` but is intended to request values *from* the tool rather than provide values *to* it. The goal of this feature is to provide a mechanism for MIPS programs to interface directly with the set of MARS tools. For example, the parameters of the Bitmap Display can be set by the program at runtime, rather than requiring manual setup by the user beforehand.

Each existing tool has been assigned an "identifier" string (such as `bitmap` for Bitmap Display and `visualstack` for Visual Stack) which is used to determine which tool is being referred to when one of the aforementioned syscalls occurs. Each syscall reads a null-terminated string from the address in `$a0` and interprets it as the tool identifier.

Below is a simple example fragment to demonstrate the utility these syscalls provide. The result of executing this code is that the Bitmap Display is launched automatically and the base address for the bitmap is set to the address of label `screen`.

```mips
    .data
BitmapDisplay:
    .asciiz "bitmap"
screen:
    .space 0x4000
    .text
    ...
    li $v0, 62 # launch tool
    la $a0, BitmapDisplay
    syscall
    li $v0, 63 # notify tool
    la $a0, BitmapDisplay
    li $a1, 1 # base address key
    la $a2, screen # Bitmap Display reads $a2 to get value
    syscall
    ...
```

Internally, the `NotifyTool` and `QueryTool` syscalls themselves are virtually identical-- they look up the tool using `$a0` and call a method (`handleNotify` / `handleQuery`) on the tool, passing in the value of `$a1` as the "key." The purpose of the key is defined by the tool, but the default implementation given by `AbstractMarsTool` uses the key to select a query / notify *handler* to run. Tools extending `AbstractMarsTool` can then use the `addNotifyHandler` and `addQueryHandler` methods to define these handlers.

At the moment, the Bitmap Display is the only tool supporting `NotifyTool` and `QueryTool`. The goal is to support this feature in all applicable tools-- this pull request is intended to lay the groundwork for future refinement.